### PR TITLE
Don't show both complete & crafting icons

### DIFF
--- a/src/components/ItemNeeded.tsx
+++ b/src/components/ItemNeeded.tsx
@@ -113,7 +113,7 @@ const ItemNeeded: React.VFC<Props> = React.memo((props) => {
             }}
           />
         )}
-        {isCrafting && canCompleteByCrafting && (
+        {!isComplete && isCrafting && canCompleteByCrafting && (
           <Tooltip arrow title="Can be completed by crafting">
             <Box
               alignSelf="center"


### PR DESCRIPTION
If there's e.g. Oriron Block in the planner as well as Oriron Cluster, and the planner originally showed the "can be completed by crafting icon" but was later marked as completed, this state was possible:
![image](https://user-images.githubusercontent.com/1508774/161880537-866947cd-1e45-4519-a906-692a5b462750.png)
Don't show the crafting hammer icon if it's already complete.