### PR TITLE
Use justify-content: center instead of m: auto for centering page content

### DIFF
--- a/src/pages/arknights/gacha.tsx
+++ b/src/pages/arknights/gacha.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Divider,
   FormControl,
   Grid,
@@ -157,159 +158,161 @@ const Gacha: NextPage = () => {
 
   return (
     <Layout page="/gacha">
-      <Grid container spacing={2} sx={{ m: "auto", maxWidth: "800px" }}>
-        <Grid item xs={6} sm={3}>
-          <ValidatedTextField
-            fullWidth
-            label="Number of pulls"
-            type="number"
-            defaultValue="0"
-            name="pulls"
-            helperText={`Max ${MAX_PULL_COUNT}`}
-            onFocus={handleFocus}
-            onChange={handleTextInputChage}
-            validator={(value) => {
-              const numericValue = parseInt(value, 10);
-              return (
-                !Number.isNaN(numericValue) &&
-                numericValue >= 0 &&
-                numericValue <= MAX_PULL_COUNT
-              );
-            }}
-          />
-        </Grid>
-
-        <Grid item xs={6} sm={3}>
-          <ValidatedTextField
-            fullWidth
-            label="Initial pity"
-            type="number"
-            defaultValue="0"
-            name="pity"
-            helperText="Between 0 and 98"
-            onFocus={handleFocus}
-            onChange={handleTextInputChage}
-            validator={(value) => {
-              const numericValue = parseInt(value, 10);
-              return (
-                !Number.isNaN(numericValue) &&
-                numericValue >= 0 &&
-                numericValue <= 98
-              );
-            }}
-          />
-        </Grid>
-
-        <Grid item xs={12} sm={6}>
-          <FormControl fullWidth>
-            <InputLabel htmlFor="banner-type">Banner type</InputLabel>
-            <Select
-              native
-              label="Banner type"
-              inputProps={{
-                name: "banner-type",
-                id: "banner-type",
+      <Box display="flex" justifyContent="center">
+        <Grid container spacing={2} sx={{ maxWidth: "800px" }}>
+          <Grid item xs={6} sm={3}>
+            <ValidatedTextField
+              fullWidth
+              label="Number of pulls"
+              type="number"
+              defaultValue="0"
+              name="pulls"
+              helperText={`Max ${MAX_PULL_COUNT}`}
+              onFocus={handleFocus}
+              onChange={handleTextInputChage}
+              validator={(value) => {
+                const numericValue = parseInt(value, 10);
+                return (
+                  !Number.isNaN(numericValue) &&
+                  numericValue >= 0 &&
+                  numericValue <= MAX_PULL_COUNT
+                );
               }}
-              onChange={handleSelectChange}
-            >
-              <option value="event">Event (one rate-up 6⭐️, 50%)</option>
-              <option value="standard">
-                Standard (two rate-up 6⭐️, each 25%)
-              </option>
-              <option value="limited">
-                Limited (two rate-up 6⭐️, each 35%)
-              </option>
-            </Select>
-          </FormControl>
-        </Grid>
+            />
+          </Grid>
 
-        <Grid item xs={12}>
-          <Paper
-            elevation={3}
-            sx={{
-              p: [2, 2, 3, 3],
-            }}
-          >
-            <Typography variant="h6" component="h3" gutterBottom>
-              Probabilities
-            </Typography>
-            <Grid container alignItems="center">
-              <Grid item xs={8}>
-                <Typography variant="body1">
-                  {!isXSmallScreen && "Chance of obtaining "}
-                  <strong>
-                    at least 1{bannerType !== "event" && " of any"}
-                  </strong>{" "}
-                  rate-up:
-                </Typography>
+          <Grid item xs={6} sm={3}>
+            <ValidatedTextField
+              fullWidth
+              label="Initial pity"
+              type="number"
+              defaultValue="0"
+              name="pity"
+              helperText="Between 0 and 98"
+              onFocus={handleFocus}
+              onChange={handleTextInputChage}
+              validator={(value) => {
+                const numericValue = parseInt(value, 10);
+                return (
+                  !Number.isNaN(numericValue) &&
+                  numericValue >= 0 &&
+                  numericValue <= 98
+                );
+              }}
+            />
+          </Grid>
+
+          <Grid item xs={12} sm={6}>
+            <FormControl fullWidth>
+              <InputLabel htmlFor="banner-type">Banner type</InputLabel>
+              <Select
+                native
+                label="Banner type"
+                inputProps={{
+                  name: "banner-type",
+                  id: "banner-type",
+                }}
+                onChange={handleSelectChange}
+              >
+                <option value="event">Event (one rate-up 6⭐️, 50%)</option>
+                <option value="standard">
+                  Standard (two rate-up 6⭐️, each 25%)
+                </option>
+                <option value="limited">
+                  Limited (two rate-up 6⭐️, each 35%)
+                </option>
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Paper
+              elevation={3}
+              sx={{
+                p: [2, 2, 3, 3],
+              }}
+            >
+              <Typography variant="h6" component="h3" gutterBottom>
+                Probabilities
+              </Typography>
+              <Grid container alignItems="center">
+                <Grid item xs={8}>
+                  <Typography variant="body1">
+                    {!isXSmallScreen && "Chance of obtaining "}
+                    <strong>
+                      at least 1{bannerType !== "event" && " of any"}
+                    </strong>{" "}
+                    rate-up:
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <Typography variant="h6" sx={{ pl: 2 }}>
+                    {toPercentage(1 - finalOdds[0][0])}
+                  </Typography>
+                </Grid>
+                {(bannerType === "standard" || bannerType === "limited") && (
+                  <>
+                    <Grid item xs={8}>
+                      <Typography variant="body1">
+                        {!isXSmallScreen && "Chance of obtaining "}
+                        <strong>at least 1 of a specific</strong> rate-up:
+                      </Typography>
+                    </Grid>
+                    <Grid item>
+                      <Typography variant="h6" sx={{ pl: 2 }}>
+                        {toPercentage(1 - finalOdds[0].reduce((a, b) => a + b))}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Typography variant="body1">
+                        {!isXSmallScreen && "Chance of obtaining "}
+                        <strong>at least 1 of each</strong> rate-up:
+                      </Typography>
+                    </Grid>
+                    <Grid item>
+                      <Typography variant="h6" sx={{ pl: 2 }}>
+                        {toPercentage(chanceOneOfEach(finalOdds))}
+                      </Typography>
+                    </Grid>
+                  </>
+                )}
               </Grid>
-              <Grid item>
-                <Typography variant="h6" sx={{ pl: 2 }}>
-                  {toPercentage(1 - finalOdds[0][0])}
-                </Typography>
+              <Divider sx={{ mt: 1, mb: 2 }} />
+              <Grid container alignItems="center" sx={{ mt: 2 }}>
+                {[...Array(7).keys()].map((i) => (
+                  <React.Fragment key={i}>
+                    <Grid item xs={8}>
+                      <Typography variant="body1">
+                        {!isXSmallScreen && "Chance of obtaining "}
+                        <strong>
+                          {i === 6 ? "6 or more" : `exactly ${i}`}
+                          {bannerType !== "event" && " of any"}
+                        </strong>{" "}
+                        rate-up
+                        {i !== 1 && "s"}:
+                      </Typography>
+                    </Grid>
+                    <Grid item>
+                      <Typography variant="h6" sx={{ pl: 2 }}>
+                        {toPercentage(
+                          bannerType === "event"
+                            ? finalOdds[i][0]
+                            : chanceMultiRateups(finalOdds, i)
+                        )}
+                      </Typography>
+                    </Grid>
+                  </React.Fragment>
+                ))}
               </Grid>
-              {(bannerType === "standard" || bannerType === "limited") && (
-                <>
-                  <Grid item xs={8}>
-                    <Typography variant="body1">
-                      {!isXSmallScreen && "Chance of obtaining "}
-                      <strong>at least 1 of a specific</strong> rate-up:
-                    </Typography>
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="h6" sx={{ pl: 2 }}>
-                      {toPercentage(1 - finalOdds[0].reduce((a, b) => a + b))}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="body1">
-                      {!isXSmallScreen && "Chance of obtaining "}
-                      <strong>at least 1 of each</strong> rate-up:
-                    </Typography>
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="h6" sx={{ pl: 2 }}>
-                      {toPercentage(chanceOneOfEach(finalOdds))}
-                    </Typography>
-                  </Grid>
-                </>
-              )}
-            </Grid>
-            <Divider sx={{ mt: 1, mb: 2 }} />
-            <Grid container alignItems="center" sx={{ mt: 2 }}>
-              {[...Array(7).keys()].map((i) => (
-                <React.Fragment key={i}>
-                  <Grid item xs={8}>
-                    <Typography variant="body1">
-                      {!isXSmallScreen && "Chance of obtaining "}
-                      <strong>
-                        {i === 6 ? "6 or more" : `exactly ${i}`}
-                        {bannerType !== "event" && " of any"}
-                      </strong>{" "}
-                      rate-up
-                      {i !== 1 && "s"}:
-                    </Typography>
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="h6" sx={{ pl: 2 }}>
-                      {toPercentage(
-                        bannerType === "event"
-                          ? finalOdds[i][0]
-                          : chanceMultiRateups(finalOdds, i)
-                      )}
-                    </Typography>
-                  </Grid>
-                </React.Fragment>
-              ))}
-            </Grid>
-          </Paper>
-          {bannerType === "limited" && (
-            <Typography variant="caption" sx={{ display: "block", mt: 2 }}>
-              * Spark system is not factored into these probabilities
-            </Typography>
-          )}
+            </Paper>
+            {bannerType === "limited" && (
+              <Typography variant="caption" sx={{ display: "block", mt: 2 }}>
+                * Spark system is not factored into these probabilities
+              </Typography>
+            )}
+          </Grid>
         </Grid>
-      </Grid>
+      </Box>
     </Layout>
   );
 };

--- a/src/pages/arknights/leveling.tsx
+++ b/src/pages/arknights/leveling.tsx
@@ -155,216 +155,229 @@ const Leveling: NextPage = () => {
 
   return (
     <Layout page="/leveling">
-      <Grid container spacing={2} sx={{ m: "auto", maxWidth: "800px" }}>
-        <Grid item xs={12}>
-          <OperatorSearch value={operator} onChange={handleChange} />
-        </Grid>
-        <Grid
-          item
-          xs={12}
-          container
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Grid item xs={12} sm={5}>
-            <Paper elevation={3} component="section" sx={sectionStyle}>
-              <Typography component="h3" variant="h5" sx={{ mb: 2 }}>
-                Start point
+      <Box display="flex" justifyContent="center">
+        <Grid container spacing={2} sx={{ maxWidth: "800px" }}>
+          <Grid item xs={12}>
+            <OperatorSearch value={operator} onChange={handleChange} />
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            container
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Grid item xs={12} sm={5}>
+              <Paper elevation={3} component="section" sx={sectionStyle}>
+                <Typography component="h3" variant="h5" sx={{ mb: 2 }}>
+                  Start point
+                </Typography>
+                <Box display="flex" flexDirection="row">
+                  <OperatorImage
+                    operator={operator}
+                    eliteLevel={startingElite}
+                  />
+                  <div>
+                    <FormControl
+                      size="small"
+                      fullWidth
+                      sx={{
+                        mb: 2,
+                      }}
+                    >
+                      <InputLabel htmlFor="starting-elite">
+                        Starting elite
+                      </InputLabel>
+                      <Select<number>
+                        disabled={!operator}
+                        native
+                        value={startingElite}
+                        label="Starting elite"
+                        onChange={handleChangeStartingElite}
+                        inputProps={{
+                          name: "starting-elite",
+                          id: "starting-elite",
+                        }}
+                      >
+                        <option value={0}>Elite 0</option>
+                        {Array(maxElite(operator?.rarity))
+                          .fill(0)
+                          .map((_, i) => (
+                            <option key={i + 1} value={i + 1}>
+                              Elite {i + 1}
+                            </option>
+                          ))}
+                      </Select>
+                    </FormControl>
+                    <ValidatedTextField
+                      size="small"
+                      fullWidth
+                      disabled={!operator}
+                      id="starting-level"
+                      label="Starting level"
+                      type="numeric"
+                      defaultValue={startingLevel}
+                      onFocus={(e) => e.target.select()}
+                      onChange={(e) =>
+                        setStartingLevel(parseInt(e.target.value, 10))
+                      }
+                      revalidateOn={[startingElite]}
+                      validator={(value) => {
+                        if (!operator) {
+                          return true;
+                        }
+                        const numericValue = parseInt(value, 10);
+                        return (
+                          !Number.isNaN(numericValue) &&
+                          numericValue >= 1 &&
+                          numericValue <= maxStartingLevel
+                        );
+                      }}
+                      helperText={startingLevelHelpText}
+                    />
+                  </div>
+                </Box>
+              </Paper>
+            </Grid>
+            <Grid item xs={2}>
+              {!isXSmallScreen ? (
+                <TrendingFlatIcon
+                  sx={{
+                    fontSize: "3rem",
+                    color: "rgba(255, 255, 255, 0.8)",
+                    stroke: "black",
+                    strokeWidth: "0.2px",
+                    width: "100%",
+                  }}
+                />
+              ) : (
+                <>&nbsp;</>
+              )}
+            </Grid>
+            <Grid item xs={12} sm={5}>
+              <Paper elevation={3} component="section" sx={sectionStyle}>
+                <Typography component="h3" variant="h5" sx={{ mb: 2 }}>
+                  End point
+                </Typography>
+                <Box display="flex" flexDirection="row">
+                  <OperatorImage operator={operator} eliteLevel={targetElite} />
+                  <div>
+                    <FormControl size="small" fullWidth sx={{ mb: 2 }}>
+                      <InputLabel htmlFor="target-elite">
+                        Target elite
+                      </InputLabel>
+                      <Select
+                        disabled={!operator}
+                        native
+                        value={targetElite}
+                        label="Target elite"
+                        onChange={(e) => {
+                          setTargetElite(
+                            parseInt(e.target.value as string, 10)
+                          );
+                        }}
+                        inputProps={{
+                          name: "target-elite",
+                          id: "target-elite",
+                        }}
+                      >
+                        <option value={0}>Elite 0</option>
+                        {Array(maxElite(operator?.rarity))
+                          .fill(0)
+                          .map((_, i) => (
+                            <option key={i + 1} value={i + 1}>
+                              Elite {i + 1}
+                            </option>
+                          ))}
+                      </Select>
+                    </FormControl>
+                    <ValidatedTextField
+                      size="small"
+                      fullWidth
+                      disabled={!operator}
+                      id="target-level"
+                      label="Target level"
+                      type="numeric"
+                      defaultValue={targetLevel}
+                      onFocus={(e) => e.target.select()}
+                      onChange={(e) =>
+                        setTargetLevel(parseInt(e.target.value, 10))
+                      }
+                      revalidateOn={[targetElite]}
+                      validator={(value) => {
+                        if (!operator) {
+                          return true;
+                        }
+                        const numericValue = parseInt(value, 10);
+                        return (
+                          !Number.isNaN(numericValue) &&
+                          numericValue >= 1 &&
+                          numericValue <= maxTargetLevel
+                        );
+                      }}
+                      helperText={targetLevelHelpText}
+                    />
+                  </div>
+                </Box>
+              </Paper>
+            </Grid>
+          </Grid>
+          <Grid item xs={12}>
+            <Paper
+              elevation={3}
+              component="section"
+              sx={{ px: 2, pt: 2, pb: 3 }}
+            >
+              <Typography component="h3" variant="h5" gutterBottom>
+                Costs
               </Typography>
-              <Box display="flex" flexDirection="row">
-                <OperatorImage operator={operator} eliteLevel={startingElite} />
-                <div>
-                  <FormControl
-                    size="small"
-                    fullWidth
+              <Box component="ul" sx={{ m: 0, p: 0, listStyle: "none" }}>
+                <Typography variant="body1" component="li">
+                  Total EXP cost:{" "}
+                  <span>
+                    <strong>{exp.toLocaleString()}</strong> EXP
+                  </span>
+                </Typography>
+                <Typography variant="body1" component="li" sx={{ mt: 1 }}>
+                  Total LMD cost:{" "}
+                  <span>
+                    <strong data-cy="lmd" data-lmd={lmd}>
+                      {lmd.toLocaleString()}
+                    </strong>{" "}
+                    <LmdIcon />
+                  </span>
+                  <Box
+                    component="ul"
                     sx={{
-                      mb: 2,
+                      mt: 1,
+                      "& > li": { display: "list-item", listStyle: "disc" },
+                      "& > li ~ li": { mt: 1 },
                     }}
                   >
-                    <InputLabel htmlFor="starting-elite">
-                      Starting elite
-                    </InputLabel>
-                    <Select<number>
-                      disabled={!operator}
-                      native
-                      value={startingElite}
-                      label="Starting elite"
-                      onChange={handleChangeStartingElite}
-                      inputProps={{
-                        name: "starting-elite",
-                        id: "starting-elite",
-                      }}
-                    >
-                      <option value={0}>Elite 0</option>
-                      {Array(maxElite(operator?.rarity))
-                        .fill(0)
-                        .map((_, i) => (
-                          <option key={i + 1} value={i + 1}>
-                            Elite {i + 1}
-                          </option>
-                        ))}
-                    </Select>
-                  </FormControl>
-                  <ValidatedTextField
-                    size="small"
-                    fullWidth
-                    disabled={!operator}
-                    id="starting-level"
-                    label="Starting level"
-                    type="numeric"
-                    defaultValue={startingLevel}
-                    onFocus={(e) => e.target.select()}
-                    onChange={(e) =>
-                      setStartingLevel(parseInt(e.target.value, 10))
-                    }
-                    revalidateOn={[startingElite]}
-                    validator={(value) => {
-                      if (!operator) {
-                        return true;
-                      }
-                      const numericValue = parseInt(value, 10);
-                      return (
-                        !Number.isNaN(numericValue) &&
-                        numericValue >= 1 &&
-                        numericValue <= maxStartingLevel
-                      );
-                    }}
-                    helperText={startingLevelHelpText}
-                  />
-                </div>
-              </Box>
-            </Paper>
-          </Grid>
-          <Grid item xs={2}>
-            {!isXSmallScreen ? (
-              <TrendingFlatIcon
-                sx={{
-                  fontSize: "3rem",
-                  color: "rgba(255, 255, 255, 0.8)",
-                  stroke: "black",
-                  strokeWidth: "0.2px",
-                  width: "100%",
-                }}
-              />
-            ) : (
-              <>&nbsp;</>
-            )}
-          </Grid>
-          <Grid item xs={12} sm={5}>
-            <Paper elevation={3} component="section" sx={sectionStyle}>
-              <Typography component="h3" variant="h5" sx={{ mb: 2 }}>
-                End point
-              </Typography>
-              <Box display="flex" flexDirection="row">
-                <OperatorImage operator={operator} eliteLevel={targetElite} />
-                <div>
-                  <FormControl size="small" fullWidth sx={{ mb: 2 }}>
-                    <InputLabel htmlFor="target-elite">Target elite</InputLabel>
-                    <Select
-                      disabled={!operator}
-                      native
-                      value={targetElite}
-                      label="Target elite"
-                      onChange={(e) => {
-                        setTargetElite(parseInt(e.target.value as string, 10));
-                      }}
-                      inputProps={{
-                        name: "target-elite",
-                        id: "target-elite",
-                      }}
-                    >
-                      <option value={0}>Elite 0</option>
-                      {Array(maxElite(operator?.rarity))
-                        .fill(0)
-                        .map((_, i) => (
-                          <option key={i + 1} value={i + 1}>
-                            Elite {i + 1}
-                          </option>
-                        ))}
-                    </Select>
-                  </FormControl>
-                  <ValidatedTextField
-                    size="small"
-                    fullWidth
-                    disabled={!operator}
-                    id="target-level"
-                    label="Target level"
-                    type="numeric"
-                    defaultValue={targetLevel}
-                    onFocus={(e) => e.target.select()}
-                    onChange={(e) =>
-                      setTargetLevel(parseInt(e.target.value, 10))
-                    }
-                    revalidateOn={[targetElite]}
-                    validator={(value) => {
-                      if (!operator) {
-                        return true;
-                      }
-                      const numericValue = parseInt(value, 10);
-                      return (
-                        !Number.isNaN(numericValue) &&
-                        numericValue >= 1 &&
-                        numericValue <= maxTargetLevel
-                      );
-                    }}
-                    helperText={targetLevelHelpText}
-                  />
-                </div>
+                    <Typography variant="body1" component="li">
+                      LMD cost for leveling:{" "}
+                      <span>
+                        <span
+                          data-cy="levelingLmd"
+                          data-leveling-lmd={levelingLmd}
+                        >
+                          {levelingLmd.toLocaleString()}
+                        </span>{" "}
+                      </span>
+                    </Typography>
+                    <Typography variant="body1" component="li">
+                      LMD cost for elite promotions:{" "}
+                      <span>
+                        <span>{eliteLmd.toLocaleString()}</span> <LmdIcon />
+                      </span>
+                    </Typography>
+                  </Box>
+                </Typography>
               </Box>
             </Paper>
           </Grid>
         </Grid>
-        <Grid item xs={12}>
-          <Paper elevation={3} component="section" sx={{ px: 2, pt: 2, pb: 3 }}>
-            <Typography component="h3" variant="h5" gutterBottom>
-              Costs
-            </Typography>
-            <Box component="ul" sx={{ m: 0, p: 0, listStyle: "none" }}>
-              <Typography variant="body1" component="li">
-                Total EXP cost:{" "}
-                <span>
-                  <strong>{exp.toLocaleString()}</strong> EXP
-                </span>
-              </Typography>
-              <Typography variant="body1" component="li" sx={{ mt: 1 }}>
-                Total LMD cost:{" "}
-                <span>
-                  <strong data-cy="lmd" data-lmd={lmd}>
-                    {lmd.toLocaleString()}
-                  </strong>{" "}
-                  <LmdIcon />
-                </span>
-                <Box
-                  component="ul"
-                  sx={{
-                    mt: 1,
-                    "& > li": { display: "list-item", listStyle: "disc" },
-                    "& > li ~ li": { mt: 1 },
-                  }}
-                >
-                  <Typography variant="body1" component="li">
-                    LMD cost for leveling:{" "}
-                    <span>
-                      <span
-                        data-cy="levelingLmd"
-                        data-leveling-lmd={levelingLmd}
-                      >
-                        {levelingLmd.toLocaleString()}
-                      </span>{" "}
-                    </span>
-                  </Typography>
-                  <Typography variant="body1" component="li">
-                    LMD cost for elite promotions:{" "}
-                    <span>
-                      <span>{eliteLmd.toLocaleString()}</span> <LmdIcon />
-                    </span>
-                  </Typography>
-                </Box>
-              </Typography>
-            </Box>
-          </Paper>
-        </Grid>
-      </Grid>
+      </Box>
     </Layout>
   );
 };


### PR DESCRIPTION
Because `<Grid>` uses negative margin, setting margin: auto overrides the necessary negative margin and breaks the layout on xs screens. Solution is to use a wrapper div with display: flex and justify-content: center to center the page content (setting this on Layout breaks other pages, as Layout's children prop can be greater than length 1).