### PR TITLE
Fix recruitment page behavior when navigated to directly

### DIFF
--- a/src/pages/arknights/recruitment.tsx
+++ b/src/pages/arknights/recruitment.tsx
@@ -71,6 +71,7 @@ const Recruitment = ({
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null);
+  const [resultPaddingTop, setResultPaddingTop] = useState(0);
   const popperRef = useRef<Instance>(null);
 
   const activeTagCombinations = getTagCombinations(activeTags);
@@ -89,6 +90,12 @@ const Recruitment = ({
       inputNode.focus();
     }
   }, [inputNode]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setResultPaddingTop(0);
+    }
+  }, [isOpen]);
 
   const handleTagsChanged = (
     _: unknown,
@@ -112,11 +119,6 @@ const Recruitment = ({
     flexWrap: "wrap",
   };
 
-  const resultPaddingTop =
-    isOpen && popperRef.current != null
-      ? popperRef.current.state.rects.popper.height
-      : 0;
-
   return (
     <Layout page="/recruitment">
       <Autocomplete
@@ -139,7 +141,22 @@ const Recruitment = ({
           />
         )}
         onChange={handleTagsChanged}
-        PopperComponent={(props) => <Popper {...props} popperRef={popperRef} />}
+        PopperComponent={(props) => (
+          <Popper
+            {...props}
+            popperRef={popperRef}
+            modifiers={[
+              {
+                name: "sizeObserver",
+                enabled: true,
+                phase: "read",
+                fn: (data) => {
+                  setResultPaddingTop(data.state.rects.popper.height);
+                },
+              },
+            ]}
+          />
+        )}
       />
       <div style={{ paddingTop: resultPaddingTop }}>
         {matchingOperators

--- a/src/pages/arknights/recruitment.tsx
+++ b/src/pages/arknights/recruitment.tsx
@@ -122,7 +122,6 @@ const Recruitment = ({
   return (
     <Layout page="/recruitment">
       <Autocomplete
-        key="input"
         options={options}
         multiple
         autoHighlight

--- a/src/pages/arknights/recruitment.tsx
+++ b/src/pages/arknights/recruitment.tsx
@@ -10,7 +10,7 @@ import {
 import { Instance } from "@popperjs/core";
 import { Combination } from "js-combinatorics";
 import { InferGetStaticPropsType } from "next";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import recruitmentJson from "../../../data/recruitment.json";
 import Layout from "../../components/Layout";
@@ -69,7 +69,8 @@ const Recruitment = ({
   options,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const [activeTags, setActiveTags] = useState<string[]>([]);
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null);
   const popperRef = useRef<Instance>(null);
 
   const activeTagCombinations = getTagCombinations(activeTags);
@@ -82,6 +83,12 @@ const Recruitment = ({
       ),
     [activeTagCombinations]
   );
+
+  useEffect(() => {
+    if (inputNode != null) {
+      inputNode.focus();
+    }
+  }, [inputNode]);
 
   const handleTagsChanged = (
     _: unknown,
@@ -117,6 +124,7 @@ const Recruitment = ({
         options={options}
         multiple
         autoHighlight
+        openOnFocus
         open={isOpen}
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
@@ -124,7 +132,11 @@ const Recruitment = ({
         getOptionLabel={(option) => option.value}
         disableCloseOnSelect
         renderInput={(params) => (
-          <TextField {...params} autoFocus label="Available recruitment tags" />
+          <TextField
+            {...params}
+            label="Available recruitment tags"
+            inputRef={setInputNode}
+          />
         )}
         onChange={handleTagsChanged}
         PopperComponent={(props) => <Popper {...props} popperRef={popperRef} />}


### PR DESCRIPTION
There must be some hydration strangeness when loading `/recruitment` directly (rather than navigating there first).

This PR should fix the behavior so that it works the same regardless of whether it's navigated to directly or via the links in the left sidebar.