### PR TITLE
Add Krooster migration notice + migration functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@reduxjs/toolkit": "^1.8.0",
     "clsx": "^1.1.1",
     "lodash.isequal": "^4.5.0",
+    "lz-string": "^1.5.0",
     "next": "^12.0.7",
     "react": "^18.0.0",
     "react-beautiful-dnd": "^13.1.0",

--- a/src/components/MaterialsNeeded.tsx
+++ b/src/components/MaterialsNeeded.tsx
@@ -230,27 +230,26 @@ const MaterialsNeeded: React.FC = React.memo(() => {
   delete materialsNeeded[LMD_ITEM_ID];
 
   const allItems: [string, number][] = Object.values(itemsJson)
-    .filter(item => !(EXCLUDE.includes(item.id)))
-    .map(item => [item.id, materialsNeeded[item.id] ?? 0]);
+    .filter((item) => !EXCLUDE.includes(item.id))
+    .map((item) => [item.id, materialsNeeded[item.id] ?? 0]);
 
-  const sortedMaterialsNeeded =
-    (showInactiveMaterials ? allItems : Object.entries(materialsNeeded)).sort(
-      ([itemIdA, neededA], [itemIdB, neededB]) => {
-        const itemA = itemsJson[itemIdA as keyof typeof itemsJson];
-        const itemB = itemsJson[itemIdB as keyof typeof itemsJson];
-        const compareBySortId = itemA.sortId - itemB.sortId;
-        if (sortCompletedToBottom) {
-          return (
-            (neededA && neededA <= stock[itemIdA] ? 1 : 0) -
-            (neededB && neededB <= stock[itemIdB] ? 1 : 0) ||
-            (canCompleteByCrafting[itemIdA] ? 1 : 0) -
-            (canCompleteByCrafting[itemIdB] ? 1 : 0) ||
-            compareBySortId
-          );
-        }
-        return compareBySortId;
-      }
-    );
+  const sortedMaterialsNeeded = (
+    showInactiveMaterials ? allItems : Object.entries(materialsNeeded)
+  ).sort(([itemIdA, neededA], [itemIdB, neededB]) => {
+    const itemA = itemsJson[itemIdA as keyof typeof itemsJson];
+    const itemB = itemsJson[itemIdB as keyof typeof itemsJson];
+    const compareBySortId = itemA.sortId - itemB.sortId;
+    if (sortCompletedToBottom) {
+      return (
+        (neededA && neededA <= stock[itemIdA] ? 1 : 0) -
+          (neededB && neededB <= stock[itemIdB] ? 1 : 0) ||
+        (canCompleteByCrafting[itemIdA] ? 1 : 0) -
+          (canCompleteByCrafting[itemIdB] ? 1 : 0) ||
+        compareBySortId
+      );
+    }
+    return compareBySortId;
+  });
 
   return (
     <Paper component="section" sx={{ p: 2 }}>

--- a/src/pages/arknights/planner.tsx
+++ b/src/pages/arknights/planner.tsx
@@ -1,4 +1,5 @@
-import { Grid } from "@mui/material";
+import { Alert, AlertTitle, Button, Grid, Link } from "@mui/material";
+import lzstring from "lz-string";
 import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
@@ -7,8 +8,9 @@ import { Operator } from "../../../scripts/output-types";
 import GoalSelect from "../../components/GoalSelect";
 import Layout from "../../components/Layout";
 import OperatorSearch from "../../components/OperatorSearch";
-import { addGoals, PlannerGoal } from "../../store/goalsSlice";
-import { useAppDispatch } from "../../store/hooks";
+import { selectDepot } from "../../store/depotSlice";
+import { addGoals, PlannerGoal, selectGoals } from "../../store/goalsSlice";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import performLegacyMigration from "../../store/performLegacyMigration";
 
 const MaterialsNeeded = dynamic(
@@ -22,6 +24,8 @@ const PlannerGoals = dynamic(() => import("../../components/PlannerGoals"), {
 const Planner: NextPage = () => {
   const [operator, setOperator] = useState<Operator | null>(null);
   const dispatch = useAppDispatch();
+  const goals = useAppSelector(selectGoals);
+  const depot = useAppSelector(selectDepot);
 
   const handleGoalsAdded = (newGoals: PlannerGoal[]) => {
     dispatch(addGoals(newGoals));
@@ -41,8 +45,49 @@ const Planner: NextPage = () => {
     }
   }, [dispatch]);
 
+  const handleMigrationClick = () => {
+    const data = { goals, depot };
+    const encoded = lzstring.compressToEncodedURIComponent(
+      JSON.stringify(data)
+    );
+    console.log("would send this:", encoded);
+    window.location.href = `http://example.com/?data=${encoded}`;
+  };
+
   return (
     <Layout page="/planner">
+      <Alert
+        severity="warning"
+        variant="outlined"
+        sx={{ mb: 3, pb: 2, maxWidth: "100ch" }}
+      >
+        <AlertTitle>Arknights Tools is now part of Krooster</AlertTitle>
+        <p>
+          Hi everyone, thank you for using samidare.io. Based on my limited free
+          time and in order to facilitate more timely updates,{" "}
+          <b>
+            Arknights Tools has merged with{" "}
+            <Link href="https://krooster.com" target="_blank" rel="noreferrer">
+              Krooster
+            </Link>
+          </b>
+          , an Arknights collection tracker.
+        </p>
+        <p>
+          This site will continue to be available, but{" "}
+          <b>this version on samidare.io won’t receive further updates</b>. If
+          you click the button below, your planner data will be copied and
+          migrated to Krooster (it won’t be deleted here). Thank you all for
+          your support!
+        </p>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={handleMigrationClick}
+        >
+          Migrate Data to Krooster
+        </Button>
+      </Alert>
       <Grid container mb={2}>
         <Grid
           item

--- a/src/pages/arknights/planner.tsx
+++ b/src/pages/arknights/planner.tsx
@@ -50,8 +50,7 @@ const Planner: NextPage = () => {
     const encoded = lzstring.compressToEncodedURIComponent(
       JSON.stringify(data)
     );
-    console.log("would send this:", encoded);
-    window.location.href = `http://example.com/?data=${encoded}`;
+    window.location.href = `https://krooster.com/planner/goals?migrate=${encoded}`;
   };
 
   return (

--- a/src/store/depotSlice.ts
+++ b/src/store/depotSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import itemsJson from "../../data/items.json";
 import { Item } from "../../scripts/output-types";
@@ -90,8 +90,12 @@ export const depotSlice = createSlice({
   },
 });
 
-export const selectStock = (state: RootState) => state.depot.stock;
-export const selectCrafting = (state: RootState) => state.depot.crafting;
+export const selectDepot = (state: RootState) => state.depot;
+export const selectStock = createSelector(selectDepot, (depot) => depot.stock);
+export const selectCrafting = createSelector(
+  selectDepot,
+  (depot) => depot.crafting
+);
 
 export const {
   subtractStock,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,6 +7828,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
Substantially based on #25's migration logic:
- displays a migration alert on the planner page (as this is the only persistent stateful page)
- adds a migration button that, when clicked, redirects to krooster.com's version of the planner with a query parameter containing the store data (using lz-string `compressToEncodedURIComponent`)

Associated Krooster PR is https://github.com/neeia/ak-roster/pull/5, which accepts the migration data